### PR TITLE
Refactor methods to mimic request jar option

### DIFF
--- a/lib/methods.js
+++ b/lib/methods.js
@@ -5,6 +5,8 @@ var request = require('request'),
 var exports = module.exports = {};
 
 var defaultedRequestObj;
+var defaultsJar;
+var globalRequestJar = request.jar();
 
 /**
 Perform HTTP request
@@ -13,7 +15,7 @@ Perform HTTP request
 @param {Object} [params] - additional request options, see the popular {@link https://github.com/request/request#requestoptions-callback request library} for options
 @returns {Promise} Promise which will resolve to a {@link ChakramResponse} object
 @alias module:chakram.request
-@example 
+@example
 var request = chakram.request("GET", "http://httpbin.org/get", {
     'auth': {'user': 'username','pass': 'password'}
 });
@@ -23,9 +25,16 @@ exports.request = function (method, url, params) {
     var options = extend({
         url: url,
         method: method,
-        json: true,
-        jar: request.jar()
+        json: true
     }, params || {} );
+
+    // options.jar is either a jar object or true
+    // In case user passes {jar: true} option to request, we need reference to global jar to do assertions.
+    options.jar = options.jar || defaultsJar;
+    if (options.jar === true) {
+        options.jar = globalRequestJar;
+    }
+
     var deferred = Q.defer();
     var reqObj = defaultedRequestObj || request;
     reqObj(options, function (error, response, body) {
@@ -143,7 +152,10 @@ Sets the default options applied to all future requests.
 @alias module:chakram.setRequestDefaults
  */
 exports.setRequestDefaults = function(defaults) {
-  defaultedRequestObj = request.defaults(defaults);
+    if (defaults.jar !== undefined) {
+        defaultsJar = defaults.jar;
+    }
+    defaultedRequestObj = request.defaults(defaults);
 };
 
 /**

--- a/lib/methods.js
+++ b/lib/methods.js
@@ -33,6 +33,9 @@ exports.request = function (method, url, params) {
     options.jar = options.jar || defaultsJar;
     if (options.jar === true) {
         options.jar = globalRequestJar;
+    } else if (options.jar === undefined) {
+        // Create new jar for this request for backwards compatibility
+        options.jar = request.jar();
     }
 
     var deferred = Q.defer();

--- a/lib/methods.js
+++ b/lib/methods.js
@@ -155,9 +155,7 @@ Sets the default options applied to all future requests.
 @alias module:chakram.setRequestDefaults
  */
 exports.setRequestDefaults = function(defaults) {
-    if (defaults.jar !== undefined) {
-        defaultsJar = defaults.jar;
-    }
+    defaultsJar = defaults.jar; // We want this copied also if it's undefined
     defaultedRequestObj = request.defaults(defaults);
 };
 

--- a/test/assertions/cookie.js
+++ b/test/assertions/cookie.js
@@ -7,6 +7,7 @@ describe("Chakram Assertions", function() {
         var cookieSet;
         
         before(function() {
+            chakram.setRequestDefaults({jar: true});
             cookieSet = chakram.get("http://httpbin.org/cookies/set?chakram=testval");
         });
         

--- a/test/assertions/cookie.js
+++ b/test/assertions/cookie.js
@@ -1,48 +1,92 @@
 var chakram = require('./../../lib/chakram.js'),
-    expect = chakram.expect;
+    expect = chakram.expect,
+    request = require('request');
 
-describe("Chakram Assertions", function() {    
+describe("Chakram Assertions", function() {
     describe("Cookies", function() {
-        
+
         var cookieSet;
-        
+
         before(function() {
-            chakram.setRequestDefaults({jar: true});
             cookieSet = chakram.get("http://httpbin.org/cookies/set?chakram=testval");
         });
-        
+
         it("should check existance of a cookie", function () {
             expect(cookieSet).to.have.cookie('chakram');
             expect(cookieSet).not.to.have.cookie('nonexistantcookie');
             return chakram.wait();
         });
-        
+
         it("should check that the cookie value matches a given string", function () {
             expect(cookieSet).to.have.cookie('chakram', 'testval');
-            
+
             expect(cookieSet).not.to.have.cookie('Chakram', 'testval');
             expect(cookieSet).not.to.have.cookie('chakram', 'est');
             expect(cookieSet).not.to.have.cookie('chakram', 'testva');
             expect(cookieSet).not.to.have.cookie('chakram', 'Testval');
             expect(cookieSet).not.to.have.cookie('chakram', '');
-            
+
             expect(cookieSet).not.to.have.cookie('nonexistantcookie', 'testval');
             return chakram.wait();
         });
-        
+
         it("should check that the cookie value satisifies regex", function () {
             expect(cookieSet).to.have.cookie('chakram', /testval/);
             expect(cookieSet).to.have.cookie('chakram', /TESTVAL/i);
             expect(cookieSet).to.have.cookie('chakram', /test.*/);
             expect(cookieSet).to.have.cookie('chakram', /te.*val/);
             expect(cookieSet).to.have.cookie('chakram', /est/);
-            
+
             expect(cookieSet).not.to.have.cookie('chakram', /\s/);
             expect(cookieSet).not.to.have.cookie('chakram', /t[s]/);
             expect(cookieSet).not.to.have.cookie('chakram', /TESTVAL/);
-            
+
             expect(cookieSet).not.to.have.cookie('nonexistantcookie', /testval/);
             return chakram.wait();
         });
-    });    
+    });
+
+    describe("Cookies internal state", function() {
+
+        var cookieSet;
+
+        it("should preserve cookies if defaults jar set to true", function() {
+            chakram.setRequestDefaults({jar: true});
+
+            cookieSet = chakram.get("http://httpbin.org/cookies/set?chakram1=testval1");
+            cookieSet = chakram.get("http://httpbin.org/cookies/set?chakram2=testval2");
+
+            expect(cookieSet).to.have.cookie('chakram1', 'testval1');
+            expect(cookieSet).to.have.cookie('chakram2', 'testval2');
+            return chakram.wait();
+        });
+
+        it("should not preserve cookies between requests on default", function() {
+
+            // Reset to default state
+            chakram.setRequestDefaults({jar: undefined});
+
+            cookieSet = chakram.get("http://httpbin.org/cookies/set?chakram1=testval1");
+            expect(cookieSet).to.have.cookie('chakram1', 'testval1');
+
+            cookieSet = chakram.get("http://httpbin.org/cookies/set?chakram2=testval2");
+            expect(cookieSet).not.to.have.cookie('chakram1', 'testval1');
+            expect(cookieSet).to.have.cookie('chakram2', 'testval2');
+            return chakram.wait();
+        });
+
+        it("should preserve cookies if defaults jar set to instance", function() {
+            var jar = request.jar();
+            chakram.setRequestDefaults({jar: jar});
+
+            cookieSet = chakram.get("http://httpbin.org/cookies/set?chakram1=testval1");
+            cookieSet = chakram.get("http://httpbin.org/cookies/set?chakram2=testval2");
+
+            expect(cookieSet).to.have.cookie('chakram1', 'testval1');
+            expect(cookieSet).to.have.cookie('chakram2', 'testval2');
+            return chakram.wait();
+        });
+
+
+    });
 });


### PR DESCRIPTION
I think it's better design not to set jar implicitly - just like request wouldn't - cookies won't be preserved between requests. Now they're not preserved anyway, because each request is sent with a new `request.jar()`, but current implementation also prevents us from setting global default jar.

So in test now I do `chakram.setRequestDefaults({jar: true});` to use global jar, just like I would with request, but I can also pass my own jar (or leave it disabled).

Let me know if you agree, and I'll add tests and squash commits
Cheers