### PR TITLE
Added options for tuning tv4 JSON schema validator

### DIFF
--- a/lib/assertions/schema.js
+++ b/lib/assertions/schema.js
@@ -27,6 +27,8 @@ it("should check that the returned JSON object satisifies a JSON schema", functi
 
 module.exports = function (chai, utils) {
 
+  var chakram = require('./../chakram');
+
   utils.addMethod(chai.Assertion.prototype, 'schema', function () {
 
     var object = this._obj.body;
@@ -38,7 +40,7 @@ module.exports = function (chai, utils) {
       object = path.get(utils, object, subElement);
     }
 
-    var validationResult = tv4.validateMultiple(object, schema);
+    var validationResult = tv4.validateMultiple(object, schema, chakram.schemaCyclicCheck, chakram.schemaBanUnknown);
 
     var composeErrorMessage = function () {
       var errorMsg = 'expected body to match JSON schema ' + JSON.stringify(schema, null, 2) + '.';

--- a/lib/chakram.js
+++ b/lib/chakram.js
@@ -98,6 +98,22 @@ exports.wait = function() {
 };
 
 /**
+Option for turning on tv4's "ban unknown properties" mode.
+@alias module:chakram.schemaBanUnknown
+@example
+chakram.schemaBanUnknown = true;
+*/
+exports.schemaBanUnknown = false;
+
+/**
+Option for turning on tv4's option to check for self-referencing objects.
+@alias module:chakram.schemaCyclicCheck
+@example
+chakram.schemaCyclicCheck = true;
+*/
+exports.schemaCyclicCheck = false;
+
+/**
 Exposes tv4's add schema method. Allows the registration of schemas used for schema validation.
 @alias module:chakram.addSchema
 @example 


### PR DESCRIPTION
Added option for turning on tv4's "ban unknown properties" mode when validating a JSON schema.
Added option for turning on tv4's ability to check for self-referencing objects when validating a JSON schema.