### PR TITLE
json expectation accepts a RegExp

### DIFF
--- a/lib/assertions/json.js
+++ b/lib/assertions/json.js
@@ -35,6 +35,9 @@ module.exports = function (chai, utils) {
         
         if(typeof(toMatch) === 'function') {
             toMatch(object);
+        } else if(toMatch.constructor == RegExp) {
+            var assert = new chai.Assertion(object);
+            assert.to.match(toMatch);
         } else {
             var assert = new chai.Assertion(object);
             utils.transferFlags(this, assert, false); 

--- a/lib/assertions/json.js
+++ b/lib/assertions/json.js
@@ -35,7 +35,7 @@ module.exports = function (chai, utils) {
         
         if(typeof(toMatch) === 'function') {
             toMatch(object);
-        } else if(toMatch.constructor == RegExp) {
+        } else if(toMatch && (toMatch.constructor == RegExp)) {
             var assert = new chai.Assertion(object);
             assert.to.match(toMatch);
         } else {

--- a/test/assertions/json.js
+++ b/test/assertions/json.js
@@ -53,9 +53,6 @@ describe("Chakram Assertions", function() {
                     expect(postRequest).to.have.json('json.str', /^test str$/)
                 ]);
             });
-            it("should be able to equal nulls", function () {
-                return expect(postRequest).to.have.json('json.empty', null);
-            });
         });
 
         var testChainedCompriseProperty = function(description, buildChain) {

--- a/test/assertions/json.js
+++ b/test/assertions/json.js
@@ -47,6 +47,17 @@ describe("Chakram Assertions", function() {
             });
         });
 
+        describe("RegExp", function () {
+            it("should ensure matches json by RegExp", function () {
+                return chakram.waitFor([
+                    expect(postRequest).to.have.json('json.str', /^test str$/)
+                ]);
+            });
+            it("should be able to equal nulls", function () {
+                return expect(postRequest).to.have.json('json.empty', null);
+            });
+        });
+
         var testChainedCompriseProperty = function(description, buildChain) {
             describe(description, function () {
                 it("should ensure body includes given json", function() {


### PR DESCRIPTION
So you can do this:

```
expect(res).to.have.json('version', /^v\d\.\d\.\d$/);
```
