### PR TITLE
Add JSON arrayLength assertion (fixes #4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
 node_modules
 coverage
 out
+npm-debug.log

--- a/lib/assertions/arrayLength.js
+++ b/lib/assertions/arrayLength.js
@@ -15,13 +15,11 @@ var path = require('./../utils/objectPath.js');
 module.exports = function (chai, utils) {
 
     utils.addMethod(chai.Assertion.prototype, 'arrayLength', function () {
-        var object, assert;
+        var object = this._obj.body;
         if (arguments.length === 2) {
-            object = path.get(utils, this._obj.body.json, arguments[0]);
-        } else {
-            object = this._obj.body.json;
+            object = path.get(utils, object, arguments[0]);
         }
-        assert = new chai.Assertion(object);
+        var assert = new chai.Assertion(object);
         utils.transferFlags(this, assert, false);
         assert.to.have.lengthOf(arguments[arguments.length-1]);
     });

--- a/lib/assertions/arrayLength.js
+++ b/lib/assertions/arrayLength.js
@@ -1,0 +1,28 @@
+var path = require('./../utils/objectPath.js');
+
+/**
+ Checks the length of an array in the response. Defaults to the body JSON. An optional first argument allows sub-element checks.
+ @alias module:chakram-expectation.arrayLength
+ @param {String} [subelement] - if specified a sub-element of the JSON body is checked, specified using dot notation
+ @param {Number} length - the expected length of the array
+ @example
+ it("should check length of array", function () {
+     var response = chakram.post("http://httpbin.org/post", ["an", "array"]);
+     expect(response).to.have.arrayLength(2);
+     return chakram.wait();
+ });
+ */
+module.exports = function (chai, utils) {
+
+    utils.addMethod(chai.Assertion.prototype, 'arrayLength', function () {
+        var object, assert;
+        if (arguments.length === 2) {
+            object = path.get(utils, this._obj.body.json, arguments[0]);
+        } else {
+            object = this._obj.body.json;
+        }
+        assert = new chai.Assertion(object);
+        utils.transferFlags(this, assert, false);
+        assert.to.have.lengthOf(arguments[arguments.length-1]);
+    });
+};

--- a/lib/assertions/index.js
+++ b/lib/assertions/index.js
@@ -12,5 +12,6 @@ module.exports = [
     require('./json.js'),
     require('./compression.js'),
     require('./comprise.js'),
-    require('./responsetime.js')
+    require('./responsetime.js'),
+    require('./arrayLength.js')
 ];

--- a/test/assertions/arrayLength.js
+++ b/test/assertions/arrayLength.js
@@ -6,15 +6,15 @@ describe("Chakram Assertions", function () {
 
     describe("arrayLength()", function () {
 
-        it("should check length of array at root", function () {
-            var response = chakram.post("http://httpbin.org/post", ["an", "array"]);
-            expect(response).to.have.arrayLength(2);
+        it("should check length of array at body root", function () {
+            var response = chakram.get("https://jsonplaceholder.typicode.com/users");
+            expect(response).to.have.arrayLength(10);
             return chakram.wait();
         });
 
         it("should check length of array in body", function () {
-            var response = chakram.post("http://httpbin.org/post", {myArr: ["an", "array"]});
-            expect(response).to.have.arrayLength("myArr", 2);
+            var response = chakram.post("http://httpbin.org/post", ["an", "array"]);
+            expect(response).to.have.arrayLength("json", 2);
             return chakram.wait();
         });
     });

--- a/test/assertions/arrayLength.js
+++ b/test/assertions/arrayLength.js
@@ -1,0 +1,21 @@
+var testsRunningInNode = (typeof global !== "undefined" ? true : false),
+    chakram = (testsRunningInNode ? global.chakram : window.chakram),
+    expect = (testsRunningInNode ? global.expect : window.expect);
+
+describe("Chakram Assertions", function () {
+
+    describe("arrayLength()", function () {
+
+        it("should check length of array at root", function () {
+            var response = chakram.post("http://httpbin.org/post", ["an", "array"]);
+            expect(response).to.have.arrayLength(2);
+            return chakram.wait();
+        });
+
+        it("should check length of array in body", function () {
+            var response = chakram.post("http://httpbin.org/post", {myArr: ["an", "array"]});
+            expect(response).to.have.arrayLength("myArr", 2);
+            return chakram.wait();
+        });
+    });
+});


### PR DESCRIPTION
I was looking for this assertion when writing some acceptance tests and saw the open issue. I did not have any luck reusing the `schema` assertion. Instead I used the `lengthOf` assertion provided by Chai.

Not related to these changes, but I noticed the following test is failing:

```
1) Random User API should return content type and server headers:
     AssertionError: expected header content-type with value text/plain; charset=utf-8 to match regex /json/
```

Let me know if you would like me to fix it and/or make other changes.