### PR TITLE
get the statusCode from this._obj if this._obj.response is undefined

### DIFF
--- a/lib/assertions/statuscode.js
+++ b/lib/assertions/statuscode.js
@@ -9,14 +9,13 @@ it("should allow checking of the response's status code", function () {
 });
  */
 
-module.exports = function (chai, utils) {
-
-    utils.addMethod(chai.Assertion.prototype, 'status', function (status) {
-        var respStatus = this._obj.response.statusCode;
-        this.assert(
-            respStatus === status, 
-            'expected status code ' + respStatus + ' to equal ' + status, 
-            'expected status code ' + respStatus + ' not to equal ' + status
-        );
-    });
+module.exports = function(chai, utils) {
+  utils.addMethod(chai.Assertion.prototype, 'status', function(status) {
+    var respStatus = this._obj.statusCode;
+    this.assert(
+      respStatus === status,
+      'expected status code ' + respStatus + ' to equal ' + status,
+      'expected status code ' + respStatus + ' not to equal ' + status
+    );
+  });
 };

--- a/lib/assertions/statuscode.js
+++ b/lib/assertions/statuscode.js
@@ -11,7 +11,10 @@ it("should allow checking of the response's status code", function () {
 
 module.exports = function(chai, utils) {
   utils.addMethod(chai.Assertion.prototype, 'status', function(status) {
-    var respStatus = this._obj.statusCode;
+    var respStatus = this._obj.response
+      ? this._obj.response.statusCode
+      : this._obj.statusCode;
+
     this.assert(
       respStatus === status,
       'expected status code ' + respStatus + ' to equal ' + status,


### PR DESCRIPTION
I am using chakram to test graphql api.

`const data = {
  ....
}  // assume this is a correct grapqhl query

const { response, body } = await chakram.post(ACCOUNT_URL, data, {
  headers: {
    spoil: moment().format('x'),
      treat: 'test-device'
  }
});

expect(response).to.have.status(400);`

It always throw "TypeError: Cannot read property 'statusCode' of undefined". I got the statusCode in this._obj not in this._obj.response. My solution is to get statusCode in this._obj if this._obj.response is undefined.